### PR TITLE
Start implementing voyage progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ shell:
 
 # Lint
 lint:
-	pipenv run flake8 voyage
-	pipenv run isort -c -df -rc voyage
+	pipenv run flake8 voyage tests
+	pipenv run isort -c -df -rc voyage tests
 
 # Run all tests
 test:

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,13 @@ postgres_init: postgres
 	-createdb -h ${POSTGRES_HOST} -p ${POSTGRES_PORT} -U postgres -O voyage voyage_test
 
 # Init DB
+# Makes sure postgres is running and then runs init_db.py
 database_init: postgres
 	pipenv run python init_db.py
+
+# Create some test fixtures in the local database
+fixtures:
+	pipenv run python fixtures.py
 
 # Connect to postgres
 pg:
@@ -41,7 +46,7 @@ pg:
 
 # Open a ipython shell with the application context
 shell:
-	pipenv run python manage.py shell
+	DISABLE_PSYCOGREEN=1 pipenv run python manage.py shell
 
 # Lint
 lint:

--- a/fixtures.py
+++ b/fixtures.py
@@ -9,7 +9,7 @@ def create_users():
         user = User(
             name='Text User {}'.format(i),
             email='TestEmail{}@example.com'.format(i),
-            profile_picture='https://robohash.org/{}.png'.format('user{}'.format(i)),
+            profile_picture='https://robohash.org/{}.png?bgset=bg1&set=set4'.format('user{}'.format(i)),
         )
         db.session.add(user)
     db.session.commit()

--- a/fixtures.py
+++ b/fixtures.py
@@ -1,0 +1,61 @@
+from voyage.app import create_app
+from voyage.extensions import db
+from voyage.models import Media, User, Voyage
+
+
+def create_users():
+    print("[*] Creating users")
+    for i in range(5):
+        user = User(
+            name='Text User {}'.format(i),
+            email='TestEmail{}@example.com'.format(i),
+            profile_picture='https://robohash.org/{}.png'.format('user{}'.format(i)),
+        )
+        db.session.add(user)
+    db.session.commit()
+
+
+def create_medias():
+    print("[*] Creating medias")
+    for i in range(1, 3):
+        media = Media(
+            series='Test tv show',
+            order=i,
+            name='Season #{}'.format(i),
+            type='tvshow',
+            chapters=list(range(1, 11)),
+        )
+        db.session.add(media)
+
+    for i in range(1, 4):
+        media = Media(
+            series='Test books',
+            order=i,
+            name='Book #{}'.format(i),
+            type='book',
+            chapters=list(range(1, 50)),
+        )
+        db.session.add(media)
+    db.session.commit()
+
+
+def create_voyages():
+    print("[*] Creating voyages")
+    voyage1 = Voyage(
+        name='Test voyage 1',
+        media=Media.query.first(),
+        owner=User.query.first(),
+    )
+
+    voyage1.add_member(User.query.offset(1).first())
+    voyage1.add_member(User.query.offset(2).first())
+
+    db.session.add(voyage1)
+    db.session.commit()
+
+
+if __name__ == "__main__":
+    with create_app().app_context():
+        create_users()
+        create_medias()
+        create_voyages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,8 +107,3 @@ def db_voyage(db_session, db_media, db_user_owner, db_user_member):
 @pytest.yield_fixture(scope='function')
 def client(app):
     yield app.test_client()
-
-
-@pytest.fixture(scope='session')
-def graph_client():
-    yield Client(schema=schema)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,10 @@ from contextlib import contextmanager
 import pytest
 from flask.testing import FlaskClient
 from flask_login import login_user
-from graphene.test import Client
 
 from voyage.app import create_app
 from voyage.extensions import db as _db
 from voyage.models import Media, User, Voyage
-from voyage.schema import schema
 
 
 class TestClient(FlaskClient):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,8 +94,8 @@ def db_voyage(db_session, db_media, db_user_owner, db_user_member):
         name='The Voyage',
         media=db_media,
         owner=db_user_owner,
-        members=[db_user_owner, db_user_member],
     )
+    voyage.add_member(db_user_member)
     db_session.add(voyage)
     db_session.commit()
 

--- a/tests/mutation_tests/test_voyage_mutations.py
+++ b/tests/mutation_tests/test_voyage_mutations.py
@@ -1,59 +1,33 @@
-def test_inviting_user_to_voyage(graph_client, db_voyage, db_user_owner, db_user, client):
+import pytest
+
+from voyage.exceptions import MutationException
+from voyage.schema.mutations.voyage import InviteUserToVoyage, RemoveUserFromVoyage
+
+
+def test_inviting_user_to_voyage(db_voyage, db_user_owner, db_user, client):
     assert db_user not in db_voyage.members
 
     with client.use(db_user_owner):
-        executed = graph_client.execute(
-            '''
-                mutation {{
-                    inviteUserToVoyage (voyageId: "{}", email: "{}") {{
-                        voyage {{
-                            id
-                        }}
-                    }}
-                }}
-            '''.format(db_voyage.id, db_user.email)
-        )
+        InviteUserToVoyage.mutate('root', 'info', db_voyage.id, db_user.email)
 
-    assert 'errors' not in executed
     assert db_user in db_voyage.members
 
 
-def test_inviting_user_only_allows_owner_to_do_it(graph_client, db_voyage, db_user_member, db_user, client):
+def test_inviting_user_only_allows_owner_to_do_it(db_voyage, db_user_member, db_user, client):
     assert db_user not in db_voyage.members
 
     with client.use(db_user_member):
-        executed = graph_client.execute(
-            '''
-                mutation {{
-                    inviteUserToVoyage (voyageId: "{}", email: "{}") {{
-                        voyage {{
-                            id
-                        }}
-                    }}
-                }}
-            '''.format(db_voyage.id, db_user.email)
-        )
+        with pytest.raises(MutationException) as exc:
+            InviteUserToVoyage.mutate('root', 'info', db_voyage.id, db_user.email)
 
-    assert 'errors' in executed
-    assert any(error['message'] == 'Only voyage owners can invite users' for error in executed['errors'])
+    assert 'Only voyage owners can invite users' in exc.exconly()
     assert db_user not in db_voyage.members
 
 
-def test_removing_a_user_from_voyage(graph_client, db_voyage, db_user_owner, db_user_member, client):
+def test_removing_a_user_from_voyage(db_voyage, db_user_owner, db_user_member, client):
     assert db_user_member in db_voyage.members
 
     with client.use(db_user_owner):
-        executed = graph_client.execute(
-            '''
-                mutation {{
-                    removeUserFromVoyage (voyageId: "{}", email: "{}") {{
-                        voyage {{
-                            id
-                        }}
-                    }}
-                }}
-            '''.format(db_voyage.id, db_user_member.email)
-        )
+        RemoveUserFromVoyage.mutate('root', 'info', db_voyage.id, db_user_member.email)
 
-    assert 'errors' not in executed
     assert db_user_member not in db_voyage.members

--- a/tests/query_tests/test_media_queries.py
+++ b/tests/query_tests/test_media_queries.py
@@ -1,11 +1,11 @@
 from voyage.schema.queries import MediaQuery
 
 
-def test_getting_all_medias(graph_client, db_media):
+def test_getting_all_medias(db_media):
     medias = MediaQuery.resolve_medias('root', 'info').all()
     assert medias == [db_media]
 
 
-def test_getting_single_media(graph_client, db_media):
+def test_getting_single_media(db_media):
     media = MediaQuery.resolve_media('root', 'info', db_media.id)
     assert media == db_media

--- a/tests/query_tests/test_user_queries.py
+++ b/tests/query_tests/test_user_queries.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 from voyage.schema.queries import UserQuery
 
 
-def test_getting_current_user(graph_client, db_user, client):
+def test_getting_current_user(db_user, client):
     with client.use(db_user):
         user = UserQuery.resolve_current_user('root', 'info')
 

--- a/tests/query_tests/test_voyage_queries.py
+++ b/tests/query_tests/test_voyage_queries.py
@@ -1,11 +1,11 @@
 from voyage.schema.queries import VoyageQuery
 
 
-def test_getting_all_voyages(graph_client, db_voyage):
+def test_getting_all_voyages(db_voyage):
     voyages = VoyageQuery.resolve_voyages('root', 'info').all()
     assert voyages == [db_voyage]
 
 
-def test_getting_single_voyage(graph_client, db_voyage):
+def test_getting_single_voyage(db_voyage):
     voyage = VoyageQuery.resolve_voyage('root', 'info', db_voyage.id)
     assert voyage == db_voyage

--- a/voyage/app.py
+++ b/voyage/app.py
@@ -7,10 +7,11 @@ from werkzeug.contrib.fixers import ProxyFix
 
 
 def create_app(testing=False):
-    from gevent.monkey import patch_all
-    patch_all()
-    from psycogreen.gevent import patch_psycopg
-    patch_psycopg()
+    if not os.environ.get('DISABLE_PSYCOGREEN'):
+        from gevent.monkey import patch_all
+        patch_all()
+        from psycogreen.gevent import patch_psycopg
+        patch_psycopg()
 
     app = Flask('voyage')
     app.wsgi_app = ProxyFix(app.wsgi_app)

--- a/voyage/exceptions/__init__.py
+++ b/voyage/exceptions/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 from .mutation import *
 from .query import *
+from .models import *

--- a/voyage/exceptions/models.py
+++ b/voyage/exceptions/models.py
@@ -1,4 +1,6 @@
 # flake8: noqa
 
 class ModelsException(Exception): pass
+
 class InvalidChapterException(ModelsException): pass
+class InvalidRoleException(ModelsException): pass

--- a/voyage/exceptions/models.py
+++ b/voyage/exceptions/models.py
@@ -1,0 +1,4 @@
+# flake8: noqa
+
+class ModelsException(Exception): pass
+class InvalidChapterException(ModelsException): pass

--- a/voyage/models/__init__.py
+++ b/voyage/models/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa
 from .media import Media
+from .membership import Membership
 from .user import OAuth, User
 from .voyage import Voyage

--- a/voyage/models/membership.py
+++ b/voyage/models/membership.py
@@ -1,8 +1,10 @@
 from sqlalchemy.orm import validates
 
-from voyage.exceptions import InvalidChapterException
+from voyage.exceptions import InvalidChapterException, InvalidRoleException
 from voyage.extensions import db
 from voyage.utils import UUIDString, uuid4_str
+
+ROLES = ['owner', 'member']
 
 
 class Membership(db.Model):
@@ -46,3 +48,9 @@ class Membership(db.Model):
             raise InvalidChapterException('Chapter {} is not available in this voyage'.format(chapter))
 
         return chapter
+
+    @validates('role')
+    def validate_role(self, key, role):
+        if role not in ROLES:
+            raise InvalidRoleException('Unknown role: {}'.format(role))
+        return role

--- a/voyage/models/membership.py
+++ b/voyage/models/membership.py
@@ -1,0 +1,48 @@
+from sqlalchemy.orm import validates
+
+from voyage.exceptions import InvalidChapterException
+from voyage.extensions import db
+from voyage.utils import UUIDString, uuid4_str
+
+
+class Membership(db.Model):
+    """ User membership in a voyage
+
+    Tracks the user progres in the voyage
+    """
+    __tablename__ = 'voyage_user_membership'
+
+    id = db.Column(UUIDString, primary_key=True, default=uuid4_str)
+
+    voyage_id = db.Column(UUIDString, db.ForeignKey('voyage.id'), nullable=False)
+    voyage = db.relationship('Voyage', backref='memberships')
+
+    user_id = db.Column(UUIDString, db.ForeignKey('user.id'), nullable=False)
+    user = db.relationship('User', backref='memberships')
+
+    active = db.Column(db.Boolean, default=True)
+    role = db.Column(db.String, default='member')
+
+    current_chapter = db.Column('current_chapter', db.String, nullable=False)
+
+    def __init__(self, user, voyage, role=None, current_chapter=None):
+        self.user = user
+        self.voyage = voyage
+
+        if role:
+            self.role = role
+
+        if current_chapter:
+            self.current_chapter = current_chapter
+        else:
+            self.current_chapter = voyage.chapters[0]
+
+    def __repr__(self):
+        return "<Membership: User '{}' in Voyage '{}' ({})>".format(self.user_id, self.voyage_id, self.id)
+
+    @validates('current_chapter')
+    def validate_current_chapter(self, key, chapter):
+        if chapter not in self.voyage.chapters:
+            raise InvalidChapterException('Chapter {} is not available in this voyage'.format(chapter))
+
+        return chapter

--- a/voyage/models/user.py
+++ b/voyage/models/user.py
@@ -2,7 +2,6 @@ from flask_dance.consumer.backend.sqla import OAuthConsumerMixin
 from flask_login import UserMixin
 
 from voyage.extensions import db
-from voyage.models.many_to_many import voyage_members_table
 from voyage.utils import UUIDString, uuid4_str
 
 
@@ -14,10 +13,19 @@ class User(db.Model, UserMixin):
     email = db.Column(db.String, unique=True)
     profile_picture = db.Column(db.String)
 
-    voyages = db.relationship('Voyage', secondary=voyage_members_table, lazy='joined')
-
     def __repr__(self):
         return "<User: {} ({})>".format(self.name, self.email)
+
+    @property
+    def voyages(self):
+        from voyage.models import Membership, Voyage
+        return (
+            Voyage.query
+            .join(Membership)
+            .filter(
+                Membership.user == self,
+            )
+        ).all()
 
 
 class OAuth(OAuthConsumerMixin, db.Model):

--- a/voyage/models/voyage.py
+++ b/voyage/models/voyage.py
@@ -1,5 +1,4 @@
 from voyage.extensions import db
-from voyage.models.many_to_many import voyage_members_table
 from voyage.utils import UUIDString, uuid4_str
 
 
@@ -12,10 +11,83 @@ class Voyage(db.Model):
     media_id = db.Column(UUIDString, db.ForeignKey('media.id'), nullable=False)
     media = db.relationship('Media')
 
-    owner_id = db.Column(UUIDString, db.ForeignKey('user.id'), nullable=False)
-    owner = db.relationship('User')
+    def __init__(self, name, media, owner):
+        from voyage.models import Membership
 
-    members = db.relationship('User', secondary=voyage_members_table, lazy='joined')
+        self.name = name
+        self.media = media
+
+        self.memberships = [
+            Membership(
+                user=owner,
+                voyage=self,
+                role='owner',
+            ),
+        ]
 
     def __repr__(self):
         return "<Voyage: {} ({})>".format(self.name, self.id)
+
+    @property
+    def members(self):
+        from voyage.models import Membership, User
+
+        return (
+            User.query
+            .join(Membership)
+            .filter(
+                Membership.voyage == self,
+            )
+        ).all()
+
+    @property
+    def owner(self):
+        from voyage.models import Membership, User
+
+        return (
+            User.query
+            .join(Membership)
+            .filter(
+                Membership.voyage == self,
+                Membership.role == 'owner',
+            )
+        ).first()
+
+    @property
+    def chapters(self):
+        return self.media.chapters
+
+    def add_member(self, user):
+        from voyage.models import Membership
+
+        exists = (
+            Membership.query
+            .filter(
+                Membership.user == user,
+                Membership.voyage == self,
+            )
+        ).first()
+
+        if exists:
+            exists.active = True
+        else:
+            self.memberships.append(
+                Membership(
+                    user=user,
+                    voyage=self,
+                )
+            )
+
+    def remove_member(self, user):
+        from voyage.models import Membership
+
+        exists = (
+            Membership.query
+            .filter(
+                Membership.user == user,
+                Membership.voyage == self,
+            )
+        ).first()
+
+        if exists:
+            exists.active = False

--- a/voyage/models/voyage.py
+++ b/voyage/models/voyage.py
@@ -37,6 +37,7 @@ class Voyage(db.Model):
             .join(Membership)
             .filter(
                 Membership.voyage == self,
+                Membership.active == True,
             )
         ).all()
 

--- a/voyage/models/voyage.py
+++ b/voyage/models/voyage.py
@@ -37,7 +37,7 @@ class Voyage(db.Model):
             .join(Membership)
             .filter(
                 Membership.voyage == self,
-                Membership.active == True,
+                Membership.active == True,  # noqa: E712
             )
         ).all()
 

--- a/voyage/schema/mutations/voyage.py
+++ b/voyage/schema/mutations/voyage.py
@@ -60,7 +60,7 @@ class InviteUserToVoyage(graphene.Mutation):
         if user in voyage.members:
             raise MutationException('User already a part of the mutation')
 
-        voyage.members.append(user)
+        voyage.add_member(user)
         db.session.commit()
 
         events.voyage.updated(voyage)
@@ -96,7 +96,7 @@ class RemoveUserFromVoyage(graphene.Mutation):
         if user is voyage.owner:
             raise MutationException("Owners can't be removed from their voyage")
 
-        voyage.members.remove(user)
+        voyage.remove_member(user)
         db.session.commit()
 
         events.voyage.updated(voyage)


### PR DESCRIPTION
Created a `Membership` association class between `User` and `Voyage`. Still not 100% sure if this is the correct way of adding progress.

I want each `User <-> Voyage` association to have metadata, such as what's the users current chapter and their notebook for the voyage.

I want to track all changes to the notebook, it'll be its own model, and I don't think I need to track the current chapter changes for any good reason, so it's just a column on the membership. I also removed the owner column on the voyage for a role column on the membership, which is either 'owner' or 'member' for now.

Spent some time looking at [association proxy](http://docs.sqlalchemy.org/en/latest/orm/extensions/associationproxy.html), but it didn't end up really fit what I wanted to do, my main issue being the creator wasn't able to access the current object (for example, the creator on the members proxy on voyage couldn't access the voyage instance itself AFAIK, meaning I couldn't easily create membership objects), though I'd love to revisit that.

Also first slice of #25 implemented here, a simple `fixtures` target to create users, medias and a voyage.

Resolves #19